### PR TITLE
Do not panic when round-tripping an empty path/contour

### DIFF
--- a/glyphs_plist/src/norad_interop.rs
+++ b/glyphs_plist/src/norad_interop.rs
@@ -12,11 +12,13 @@ impl From<&norad::Contour> for Path {
             .iter()
             .map(|contour| contour.into())
             .collect();
-        if contour.is_closed() {
+
+        if contour.is_closed() && !nodes.is_empty() {
             // In Glyphs.app, the starting node of a closed contour is
             // always stored at the end of the nodes list.
             nodes.rotate_left(1);
         }
+
         Self {
             attr: None,
             closed: contour.is_closed(),
@@ -34,14 +36,17 @@ impl TryFrom<&Path> for norad::Contour {
             .iter()
             .map(|node| node.try_into())
             .collect::<Result<Vec<norad::ContourPoint>, _>>()?;
-        if !path.closed {
-            // This logic comes from glyphsLib.
-            assert!(points[0].typ == norad::PointType::Line);
-            points[0].typ = norad::PointType::Move;
-        } else {
-            // In Glyphs.app, the starting node of a closed contour is
-            // always stored at the end of the nodes list.
-            points.rotate_right(1);
+
+        if !points.is_empty() {
+            if !path.closed {
+                // This logic comes from glyphsLib.
+                assert!(points[0].typ == norad::PointType::Line);
+                points[0].typ = norad::PointType::Move;
+            } else {
+                // In Glyphs.app, the starting node of a closed contour is
+                // always stored at the end of the nodes list.
+                points.rotate_right(1);
+            }
         }
         Ok(Self::new(points, None, None))
     }

--- a/glyphs_plist/tests/lib.rs
+++ b/glyphs_plist/tests/lib.rs
@@ -59,3 +59,24 @@ fn open_contour_smooth_point() {
         )]
     );
 }
+
+#[test]
+fn roundtrip_empty_path() {
+    // Round-tripping paths without any nodes should not cause panics; they are
+    // representable in both file formats and can be loaded or created in
+    // Glyphs, even if not directly through the UI.
+    let path_source = r#"
+        {
+            nodes = ();
+        }
+    "#;
+
+    let plist = Plist::parse(path_source).unwrap();
+
+    let path = glyphs_plist::Path::try_from(plist).unwrap();
+    let contour = norad::Contour::try_from(&path).unwrap();
+    let path_again = glyphs_plist::Path::from(&contour);
+
+    assert!(path.nodes.is_empty());
+    assert_eq!(path, path_again);
+}


### PR DESCRIPTION
Round-tripping paths without any nodes should not cause panics; they are representable in both file formats and can be loaded or created in Glyphs, even if not directly through the UI.