### PR TITLE
Be more tolerant of bools masquerading as strings

### DIFF
--- a/glyphs_plist/src/font.rs
+++ b/glyphs_plist/src/font.rs
@@ -926,10 +926,10 @@ impl TryFrom<Plist> for InstanceType {
     type Error = InstanceTypeConversionError;
 
     fn try_from(plist: Plist) -> Result<Self, Self::Error> {
-        if let Plist::String(inner) = plist {
-            if inner == "variable" {
-                return Ok(InstanceType::Variable);
-            }
+        if let Plist::String(inner) = plist
+            && inner == "variable"
+        {
+            return Ok(InstanceType::Variable);
         }
         Err(InstanceTypeConversionError)
     }

--- a/glyphs_plist/src/font.rs
+++ b/glyphs_plist/src/font.rs
@@ -63,6 +63,8 @@ pub struct Axis {
     pub tag: String,
     #[plist(default)]
     pub hidden: bool,
+    #[plist(default)]
+    pub default: f64,
 }
 
 #[derive(Clone, Debug, FromPlist, ToPlist, PartialEq)]
@@ -251,12 +253,12 @@ pub struct PathAttrs {
     pub identifier: Option<String>,
     pub line_cap_start: Option<f64>,
     pub line_cap_end: Option<f64>,
-    pub stroke_pos: Option<i64>,
+    pub stroke_pos: Option<f64>,
     pub stroke_height: Option<f64>,
     pub stroke_width: Option<f64>,
     pub stroke_color: Option<Vec<i64>>,
-    pub mask: Option<i64>,
-    pub fill: Option<i64>,
+    pub mask: Option<bool>,
+    pub fill: Option<bool>,
     pub fill_color: Option<Vec<i64>>,
     pub shadow: Option<PathShadow>,
     pub gradient: Option<PathGradient>,

--- a/glyphs_plist/src/from_plist.rs
+++ b/glyphs_plist/src/from_plist.rs
@@ -48,11 +48,7 @@ impl TryFrom<Plist> for i64 {
     type Error = VariantError;
 
     fn try_from(plist: Plist) -> Result<Self, Self::Error> {
-        match plist {
-            Plist::Integer(i) => Ok(i),
-            Plist::String(s) => s.parse::<i64>().or(Err(VariantError("integer"))),
-            _ => Err(VariantError("integer")),
-        }
+        plist.as_i64().ok_or(VariantError("integer"))
     }
 }
 

--- a/glyphs_plist/src/from_plist.rs
+++ b/glyphs_plist/src/from_plist.rs
@@ -23,14 +23,20 @@ impl TryFrom<Plist> for bool {
     type Error = BoolConversionError;
 
     fn try_from(plist: Plist) -> Result<Self, Self::Error> {
-        plist
-            .as_i64()
-            .ok_or(BoolConversionError::WrongVariant)
-            .and_then(|n| match n {
-                0 => Ok(false),
-                1 => Ok(true),
-                _ => Err(BoolConversionError::BadNumber(n)),
-            })
+        let convert_number = |n| match n {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(BoolConversionError::BadNumber(n)),
+        };
+
+        match plist {
+            Plist::Integer(n) => convert_number(n),
+            Plist::String(s) => match s.parse::<i64>() {
+                Ok(n) => convert_number(n),
+                Err(_) => Err(BoolConversionError::WrongVariant),
+            },
+            _ => Err(BoolConversionError::WrongVariant),
+        }
     }
 }
 
@@ -42,7 +48,11 @@ impl TryFrom<Plist> for i64 {
     type Error = VariantError;
 
     fn try_from(plist: Plist) -> Result<Self, Self::Error> {
-        plist.as_i64().ok_or(VariantError("integer"))
+        match plist {
+            Plist::Integer(i) => Ok(i),
+            Plist::String(s) => s.parse::<i64>().or(Err(VariantError("integer"))),
+            _ => Err(VariantError("integer")),
+        }
     }
 }
 


### PR DESCRIPTION
Found a file where this is an issue. Tempted to do the same for all number fields, but maybe not now.

Also add the `default` field for axes.